### PR TITLE
Replace Roboto Mono and Space Grotesk with Geist fonts

### DIFF
--- a/css/design-system.css
+++ b/css/design-system.css
@@ -1,11 +1,11 @@
 /* ═══════════════════════════════════════════════════════════
    :probabl. Design System — CSS Custom Properties
    Brand Guidelines v1 · Persian Blue × Sea Buckthorn
-   Google Fonts: Roboto Mono (primary) + Space Grotesk (body)
+   Google Fonts: Geist Mono (mono) + Geist (body)
    ═══════════════════════════════════════════════════════════ */
 
 /* ── Google Fonts ──────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;500;600;700&family=Space+Grotesk:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@300;400;500;600;700&family=Geist:wght@300;400;500;600;700&display=swap');
 
 /* ── Brand Color Scale ─────────────────────────────────────── */
 :root {
@@ -84,8 +84,8 @@
   --status-archived-bg:  #F1F5F9;
 
   /* ── Typography ───────────────────────────────────────────── */
-  --font-mono:   'Roboto Mono', 'Courier New', monospace;
-  --font-body:   'Space Grotesk', system-ui, -apple-system, sans-serif;
+  --font-mono:   'Geist Mono', 'Courier New', monospace;
+  --font-body:   'Geist', system-ui, -apple-system, sans-serif;
 
   /* Type scale */
   --text-xs:     0.65rem;    /* 10.4px */

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@300;400;500;600;700&family=Geist:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
   <!-- Font Awesome -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" crossorigin="anonymous">


### PR DESCRIPTION
## Changes

- Updated font imports from Google Fonts to use **Geist Mono** (monospace) and **Geist** (body) typefaces
- Modified `css/design-system.css` CSS custom properties for `--font-mono` and `--font-body`
- Updated font import URL in `index.html` to match new font families
- Updated design system header comments to reflect new font choices

## Files Changed

- `css/design-system.css`: Updated @import URL and CSS variables
- `index.html`: Updated Google Fonts link tag