### PR TITLE
Add Google Tag Manager code

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+<head>  
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Scikit-learn Central — Packages &amp; Use Cases</title>
   <meta name="description" content="The official scikit-learn ecosystem catalog and real-world use case explorer, by :probabl.">
 
+  <!-- Google Tag Manager -->
+  <script>
+    // 1. Initialize Data Layer & GTM Stub
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+
+    // 2. Set Default Consent to 'Denied'
+    // This ensures compliance before GTM loads. Tags will not fire yet.
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+  </script>
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-M9JXX8MX');</script>
+  <!-- End Google Tag Manager -->
+  
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
This PR adds Google Tag Manager to handle consent banners and analytics trackers, ensuring parity with our existing web properties.