### PR TITLE
fix: pin wrangler to v4 for stable Python worker support

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -21,4 +21,5 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          wranglerVersion: "4"
           workingDirectory: mcp


### PR DESCRIPTION
## Summary

- Pins `wrangler-action` to wrangler v4, which has stable (non-experimental) Python worker support
- Wrangler 3.90 flagged Python workers as experimental; v4 promotes them to stable

## Root cause of the failed deploy

The GitHub Actions run triggered by the #26 merge failed for two reasons:
1. **`CLOUDFLARE_API_TOKEN` secret not set** — needs to be added to repo secrets (Settings → Secrets → Actions) before the workflow can deploy
2. **Wrangler 3.x** — used the old version that treats Python workers as experimental; this PR fixes it

## Test plan

- [ ] Add `CLOUDFLARE_API_TOKEN` secret to repo (Cloudflare token with Workers Scripts: Edit permission)
- [ ] Re-run the Deploy MCP Server workflow (or push any change to `data/` or `mcp/`)
- [ ] Verify successful deploy and test the live endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)