### PR TITLE
Let forks override the Pages CNAME via the PAGES_CNAME repo variable

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Build site (dist/ + dist/jupyterlite/)
         run: pixi run build
 
+      # Forks can override the bundled CNAME by setting the PAGES_CNAME repo
+      # variable. Upstream leaves it unset and ships the canonical domain.
+      - name: Override CNAME for forks
+        if: vars.PAGES_CNAME != ''
+        run: echo "${{ vars.PAGES_CNAME }}" > dist/CNAME
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
When PAGES_CNAME is set on the repo (e.g. on a fork), the Pages deploy writes that hostname into dist/CNAME, overriding the bundled value. Upstream leaves the variable unset and ships the canonical domain unchanged, so forks can serve from their own domain without touching the committed CNAME file.