### PR TITLE
fix: Correct the sorting based on the score

### DIFF
--- a/src/composables/usePackages.ts
+++ b/src/composables/usePackages.ts
@@ -36,10 +36,6 @@ const DAY_MS = 24 * 60 * 60 * 1000
  *  1-week-old commit ≈ 97, 6-month-old ≈ 50, 2-year-old ≈ 13. */
 const ACTIVITY_HALF_LIFE_DAYS = 180
 
-/** Probabl-core stewardship boost added on top of fitBase. Large on purpose:
- *  Probabl-maintained core libraries should surface at the top of the catalog. */
-const PROBABL_BOOST = 100
-
 function daysSince(iso: string | undefined): number | null {
   if (!iso) return null
   const t = new Date(iso).getTime()
@@ -106,7 +102,6 @@ function buildPackages(useCases: ReturnType<typeof useUseCases>['useCases']): Pa
       fitDocs: 0,
       fitTesting: 0,
       fitBase: 0,
-      fitTotal: 0,
     }
   })
 
@@ -157,8 +152,6 @@ function buildPackages(useCases: ReturnType<typeof useUseCases>['useCases']): Pa
       W_ADOPTION * p.fitAdoption +
       W_DOCS * p.fitDocs +
       W_TESTING * p.fitTesting
-
-    p.fitTotal = p.fitBase + (p.probabl ? PROBABL_BOOST : 0)
   })
 
   return withStats
@@ -199,7 +192,6 @@ export const FIT_WEIGHTS = {
 } as const
 
 export const FIT_ACTIVITY_HALF_LIFE_DAYS = ACTIVITY_HALF_LIFE_DAYS
-export const FIT_PROBABL_BOOST = PROBABL_BOOST
 
 export function usePackages(): UsePackages {
   if (!cachedPackages) {

--- a/src/types/package.ts
+++ b/src/types/package.ts
@@ -121,8 +121,7 @@ export interface PackageRaw {
   archived?: boolean
   description: string
   tags: string[]
-  /** Marks a package maintained by Probabl. Drives a Fit Score boost so the
-   *  steward's libraries surface prominently in default rankings. */
+  /** Marks a package maintained by Probabl (metadata for editorial workflows). */
   probabl?: boolean
   /** Override the codecov/coveralls slug when it differs from the GitHub
    *  repo path. Consumed by `scripts/update_stats.py`. */
@@ -163,8 +162,6 @@ export interface Package extends PackageRaw {
   fitTesting: number
   /** Weighted sum of the six sub-scores, 0–100. */
   fitBase: number
-  /** fitBase plus the Probabl-core stewardship boost, if any. */
-  fitTotal: number
 }
 
 export interface PackageStats {

--- a/src/views/PackagesView.vue
+++ b/src/views/PackagesView.vue
@@ -115,7 +115,7 @@ const filtered = computed(() => {
     if (sortBy.value === 'name') return a.name.localeCompare(b.name)
     if (sortBy.value === 'stars') return (b.stars ?? 0) - (a.stars ?? 0)
     if (sortBy.value === 'downloads') return (b.downloads ?? 0) - (a.downloads ?? 0)
-    return (b.fitTotal ?? 0) - (a.fitTotal ?? 0)
+    return (b.fitBase ?? 0) - (a.fitBase ?? 0)
   })
   return r
 })


### PR DESCRIPTION
Removing the probabl boost score since we are using the featured package now.