### PR TITLE
chore: Switch from JupyterLab to Jupyter Notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ The reference skill lives at `.claude/skills/emil-design-eng/SKILL.md` (loaded b
 
 ## JupyterLite integration
 
-Each use-case card has an **Open in JupyterLite** action that launches a fully interactive JupyterLab tab with the use case's notebook pre-opened. The kernel is Pyodide (Python + scikit-learn in WebAssembly), so it runs entirely client-side.
+Each use-case card has an **Open in JupyterLite** action that launches a fully interactive Jupyter Notebook tab with the use case's notebook pre-opened. The kernel is Pyodide (Python + scikit-learn in WebAssembly), so it runs entirely client-side.
 
 CI builds the JupyterLite distribution on every deploy: `.py` files under `data/use-cases/` are converted to `.ipynb` via [jupytext](https://jupytext.readthedocs.io/), then `jupyter lite build` writes the static site into `dist/jupyterlite/` (served at `/jupyterlite/` by GitHub Pages, alongside the Vue app).
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -16,7 +16,7 @@ beautifulsoup4 = "*"
 lxml = "*"
 
 # JupyterLite toolchain — converts use-case .py → .ipynb and builds the
-# in-browser JupyterLab static site. Versions pinned to the same ones the
+# in-browser JupyterLite static site (Lab + Notebook apps). Versions pinned to the same ones the
 # upstream skeleton-deploy ships.
 [feature.jupyterlite.dependencies]
 python = ">=3.11,<3.13"

--- a/src/composables/useUseCaseCatalogItem.ts
+++ b/src/composables/useUseCaseCatalogItem.ts
@@ -93,7 +93,8 @@ export function useUseCaseCatalogItem(
   )
 
   const jupyterliteUrl = computed(
-    () => `jupyterlite/lab/index.html?path=use-cases/${props.useCase.uuid}.ipynb`,
+    () =>
+      `jupyterlite/notebooks/index.html?path=use-cases/${props.useCase.uuid}.ipynb`,
   )
 
   const classificationRows = computed((): ClassificationRow[] => [


### PR DESCRIPTION
closes #68 

Switch from JupyterLab to Jupyter Notebook which better fit the needs for a single use-case without the file browser and thus simplify already the UX even on mobile.